### PR TITLE
AUTO-566 && AUTO-592 -- Bigger apriltags and central launch

### DIFF
--- a/cfg/dexory_arri_tags_36h11.yaml
+++ b/cfg/dexory_arri_tags_36h11.yaml
@@ -13,14 +13,14 @@
             refine: 1           # snap to strong gradients
             debug: 0            # write additional debugging images to current working directory
         tag:
-          ids:    [0, 1, 2, 3]         # tag IDs for which to publish transform
-          frames: [ta_0, ta_1, ta_2, ta_3]   # frame names
-          sizes:  [0.16, 0.06, 0.16, 0.06]     # tag-specific edge size, overrides the default 'size'
+          ids:    [0, 2]         # tag IDs for which to publish transform
+          frames: [ta_0, ta_2]   # frame names
+          sizes:  [0.16, 0.16]     # tag-specific edge size, overrides the default 'size'
         bundle:
           name: dock_bundle
-          ids: [0, 1, 2, 3]
+          ids: [0, 2]
           layout: # {X_POS, Y_POS, Z_POS, QUAT_W_VAL, QUAT_X_VAL, QUAT_Y_VAL, QUAT_Z_VAL}
-            tag_0: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] #  left big tag -- origin
-            tag_1: [0.21, 0.08, 0.0, 1.0, 0.0, 0.0, 0.0] # left small tag
-            tag_2: [0.41, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] #  right big tag
-            tag_3: [0.31, 0.08, 0.0, 1.0, 0.0, 0.0, 0.0] # right small tag
+            tag_0: [0.0, 0.02, 0.0, 1.0, 0.0, 0.0, 0.0] #  left big tag -- origin
+            tag_1: [0.20, 0.08, 0.0, 1.0, 0.0, 0.0, 0.0] # left small tag
+            tag_2: [0.411, 0.02, 0.0, 1.0, 0.0, 0.0, 0.0] #  right big tag
+            tag_3: [0.322, 0.08, 0.0, 1.0, 0.0, 0.0, 0.0] # right small tag

--- a/cfg/dexory_arri_tags_36h11.yaml
+++ b/cfg/dexory_arri_tags_36h11.yaml
@@ -2,7 +2,7 @@
     ros__parameters:
         image_transport: raw    # image format
         family: 36h11           # tag family name
-        size: 0.075             # tag edge size in meter
+        size: 0.068             # tag edge size in meter
         max_hamming: 0          # maximum allowed hamming distance (corrected bits)
 
         # see "apriltag.h" 'struct apriltag_detector' for more documentation on these optional parameters
@@ -14,13 +14,13 @@
             debug: 0            # write additional debugging images to current working directory
         tag:
           ids:    [0, 1, 2, 3]         # tag IDs for which to publish transform
-          frames: [tc_0, tc_1, tc_2, tc_3]   # frame names
-          sizes:  [0.077, 0.031, 0.077, 0.031]     # tag-specific edge size, overrides the default 'size'
+          frames: [ta_0, ta_1, ta_2, ta_3]   # frame names
+          sizes:  [0.16, 0.06, 0.16, 0.06]     # tag-specific edge size, overrides the default 'size'
         bundle:
           name: dock_bundle
           ids: [0, 1, 2, 3]
           layout: # {X_POS, Y_POS, Z_POS, QUAT_W_VAL, QUAT_X_VAL, QUAT_Y_VAL, QUAT_Z_VAL}
-            tag_0: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
-            tag_1: [0.063, 0.019, 0.0, 1.0, 0.0, 0.0, 0.0]
-            tag_2: [0.174, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
-            tag_3: [0.111, 0.019, 0.0, 1.0, 0.0, 0.0, 0.0]
+            tag_0: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] #  left big tag -- origin
+            tag_1: [0.21, 0.08, 0.0, 1.0, 0.0, 0.0, 0.0] # left small tag
+            tag_2: [0.41, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] #  right big tag
+            tag_3: [0.31, 0.08, 0.0, 1.0, 0.0, 0.0, 0.0] # right small tag

--- a/cfg/dexory_mim_tags_36h11.yaml
+++ b/cfg/dexory_mim_tags_36h11.yaml
@@ -1,0 +1,26 @@
+/**:
+    ros__parameters:
+        image_transport: raw    # image format
+        family: 36h11           # tag family name
+        size: 0.075             # tag edge size in meter
+        max_hamming: 0          # maximum allowed hamming distance (corrected bits)
+
+        # see "apriltag.h" 'struct apriltag_detector' for more documentation on these optional parameters
+        detector:
+            threads: 2          # number of threads
+            decimate: 1.0       # decimate resolution for quad detection
+            blur: 0.0           # sigma of Gaussian blur for quad detection
+            refine: 1           # snap to strong gradients
+            debug: 0            # write additional debugging images to current working directory
+        tag:
+          ids:    [0, 1, 2, 3]         # tag IDs for which to publish transform
+          frames: [tm_0, tm_1, tm_2, tm_3]   # frame names
+          sizes:  [0.077, 0.031, 0.077, 0.031]     # tag-specific edge size, overrides the default 'size'
+        bundle:
+          name: dock_bundle
+          ids: [0, 1, 2, 3]
+          layout: # {X_POS, Y_POS, Z_POS, QUAT_W_VAL, QUAT_X_VAL, QUAT_Y_VAL, QUAT_Z_VAL}
+            tag_0: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+            tag_1: [0.063, 0.019, 0.0, 1.0, 0.0, 0.0, 0.0]
+            tag_2: [0.174, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+            tag_3: [0.111, 0.019, 0.0, 1.0, 0.0, 0.0, 0.0]

--- a/cfg/elp_generic_calibration.yaml
+++ b/cfg/elp_generic_calibration.yaml
@@ -1,0 +1,26 @@
+image_width: 640
+image_height: 480
+camera_name: camera_rear_ros
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [359.87898,   0.     , 326.52872,
+           0.     , 357.87451, 206.17533,
+           0.     ,   0.     ,   1.     ]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.307032, 0.071869, 0.004066, -0.001025, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1., 0., 0.,
+         0., 1., 0.,
+         0., 0., 1.]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [254.36867,   0.     , 323.54638,   0.     ,
+           0.     , 293.15536, 193.78615,   0.     ,
+           0.     ,   0.     ,   1.     ,   0.     ]

--- a/launch/dexory_tags.launch.py
+++ b/launch/dexory_tags.launch.py
@@ -1,0 +1,31 @@
+from os import getenv
+from launch import LaunchDescription
+from launch.actions import (DeclareLaunchArgument, GroupAction,
+                            IncludeLaunchDescription, SetEnvironmentVariable)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from ament_index_python.packages import get_package_share_directory
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+ARGUMENTS = []
+
+def generate_launch_description():
+    use_sim_time = LaunchConfiguration(
+        'use_sim_time', default=(getenv('SIMULATION') == 'true'))
+
+    # april_tag_detector
+    detector_launch_file = "/launch/elp_36h11.launch.yml"
+    if use_sim_time:
+        detector_launch_file = "/launch/gazebo_elp_36h11.launch.yml"
+
+    tag_format = "mim"
+    if getenv('USE_BIG_APRIL_TAGS') == 'true':
+        tag_format = "arri"
+
+    # Define LaunchDescription variable
+    ld = LaunchDescription(ARGUMENTS)
+    ld.add_action(IncludeLaunchDescription(AnyLaunchDescriptionSource(
+        get_package_share_directory('apriltag_ros') +
+        detector_launch_file),launch_arguments=[("tag_format", tag_format)],
+    ))
+    return ld

--- a/launch/dexory_tags.launch.py
+++ b/launch/dexory_tags.launch.py
@@ -18,9 +18,7 @@ def generate_launch_description():
     detector_launch_file = "/launch/elp_36h11.launch.yml"
     sim_detector_launch_file = "/launch/gazebo_elp_36h11.launch.yml"
 
-    tag_format = "mim"
-    if getenv('USE_BIG_APRIL_TAGS') == 'true':
-        tag_format = "arri"
+    tag_format = "arri"
 
     # Define LaunchDescription variable
     ld = LaunchDescription(ARGUMENTS)

--- a/launch/dexory_tags.launch.py
+++ b/launch/dexory_tags.launch.py
@@ -4,6 +4,7 @@ from launch.actions import (DeclareLaunchArgument, GroupAction,
                             IncludeLaunchDescription, SetEnvironmentVariable)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
+from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from ament_index_python.packages import get_package_share_directory
 from launch.launch_description_sources import AnyLaunchDescriptionSource
@@ -15,8 +16,7 @@ def generate_launch_description():
 
     # april_tag_detector
     detector_launch_file = "/launch/elp_36h11.launch.yml"
-    if use_sim_time:
-        detector_launch_file = "/launch/gazebo_elp_36h11.launch.yml"
+    sim_detector_launch_file = "/launch/gazebo_elp_36h11.launch.yml"
 
     tag_format = "mim"
     if getenv('USE_BIG_APRIL_TAGS') == 'true':
@@ -27,5 +27,11 @@ def generate_launch_description():
     ld.add_action(IncludeLaunchDescription(AnyLaunchDescriptionSource(
         get_package_share_directory('apriltag_ros') +
         detector_launch_file),launch_arguments=[("tag_format", tag_format)],
+        condition=UnlessCondition(use_sim_time)
+    ))
+    ld.add_action(IncludeLaunchDescription(AnyLaunchDescriptionSource(
+        get_package_share_directory('apriltag_ros') +
+        sim_detector_launch_file),launch_arguments=[("tag_format", tag_format)],
+        condition=IfCondition(use_sim_time)
     ))
     return ld

--- a/launch/elp_36h11.launch.yml
+++ b/launch/elp_36h11.launch.yml
@@ -18,6 +18,8 @@ launch:
         value: $(var device)
       - name: camera_frame_id
         value: elp_back_base_camera_frame
+      - name: camera_info_url
+        value: $(find-pkg-share apriltag_ros)/cfg/elp_generic_calibration.yaml
       extra_arg:
       - name: use_intra_process_comms
         value: "True"
@@ -43,7 +45,7 @@ launch:
       - from: /apriltag/camera_info
         to: /elp_back_base/camera_info
       param:
-      - from: $(find-pkg-share apriltag_ros)/cfg/dexory_tags_36h11.yaml
+      - from: $(find-pkg-share apriltag_ros)/cfg/dexory_arri_tags_36h11.yaml
       extra_arg:
       - name: use_intra_process_comms
         value: "True"

--- a/launch/elp_36h11.launch.yml
+++ b/launch/elp_36h11.launch.yml
@@ -1,9 +1,6 @@
 launch:
-- arg:
-    name: device
-    default: "/dev/cameras/ros/rear"
-    name: tag_format
-    default: "mim"
+- arg: { name: device, default: "/dev/cameras/ros/rear"}
+- arg: { name: tag_format, default: "mim"}
 
 - node_container:
     pkg: rclcpp_components

--- a/launch/elp_36h11.launch.yml
+++ b/launch/elp_36h11.launch.yml
@@ -2,6 +2,8 @@ launch:
 - arg:
     name: device
     default: "/dev/cameras/ros/rear"
+    name: tag_format
+    default: "mim"
 
 - node_container:
     pkg: rclcpp_components
@@ -45,7 +47,7 @@ launch:
       - from: /apriltag/camera_info
         to: /elp_back_base/camera_info
       param:
-      - from: $(find-pkg-share apriltag_ros)/cfg/dexory_arri_tags_36h11.yaml
+      - from: $(find-pkg-share apriltag_ros)/cfg/dexory_$(var tag_format)_tags_36h11.yaml
       extra_arg:
       - name: use_intra_process_comms
         value: "True"

--- a/launch/elp_36h11.launch.yml
+++ b/launch/elp_36h11.launch.yml
@@ -1,6 +1,6 @@
 launch:
 - arg: { name: device, default: "/dev/cameras/ros/rear"}
-- arg: { name: tag_format, default: "mim"}
+- arg: { name: tag_format, default: "arri"}
 
 - node_container:
     pkg: rclcpp_components

--- a/launch/gazebo_elp_36h11.launch.yml
+++ b/launch/gazebo_elp_36h11.launch.yml
@@ -1,9 +1,6 @@
 launch:
-- arg:
-    name: device
-    default: "/dev/cameras/ros/rear"
-    name: tag_format
-    default: "arri"
+- arg: { name: device, default: "/dev/cameras/ros/rear"}
+- arg: { name: tag_format, default: "arri"}
 
 - node_container:
     pkg: rclcpp_components

--- a/launch/gazebo_elp_36h11.launch.yml
+++ b/launch/gazebo_elp_36h11.launch.yml
@@ -2,6 +2,8 @@ launch:
 - arg:
     name: device
     default: "/dev/cameras/ros/rear"
+    name: tag_format
+    default: "arri"
 
 - node_container:
     pkg: rclcpp_components
@@ -27,7 +29,7 @@ launch:
       - from: /apriltag/camera_info
         to: /cameras/elp_back_base/camera_info
       param:
-      - from: $(find-pkg-share apriltag_ros)/cfg/dexory_tags_36h11.yaml
+      - from: $(find-pkg-share apriltag_ros)/cfg/dexory_$(var tag_format)_tags_36h11.yaml
       extra_arg:
       - name: use_intra_process_comms
         value: "True"


### PR DESCRIPTION
This PR adds a couple of things important for the docking system:
- a config file for the larger-size tags
- a generic, baseline camera calibration that is read by the camera driver on the robot -- this saves us having to keep this file separately or use some OS-supplied default
- a new centralised launch `dexory_tags.launch.py` which will bring up the tag detector pipeline, using the environment variable `USE_BIG_APRIL_TAGS` to launch in the right mode. By default this is false, and the detector comes up in the mode for detecting smaller, mim-style tags.

Examples: 

`ros2 launch apriltag_ros dexory_tags.launch.py` 